### PR TITLE
Update urls for repositories, etc

### DIFF
--- a/repositories.md
+++ b/repositories.md
@@ -19,11 +19,11 @@ supporting all previous releases of Ubuntu and Debian and their derivates.
 
 To use this repository, first add the Thinkpads.org owner's GPG key:
 
-`wget -q -O - http://thinkpads.org/repo/thinkpads.gpg.key | sudo apt-key add - `   
+`wget -q -O - http://libthinkpad.github.io/repo/thinkpads.gpg.key | sudo apt-key add - `   
 
 Next, issue this command to add the APT repo to your system:
 
-`echo "deb [arch=amd64] https://thinkpads.org/repo/apt/ /" | sudo tee /etc/apt/sources.list.d/thinkpads.list`    
+`echo "deb [arch=amd64] https://libthinkpad.github.io/repo/apt/ /" | sudo tee /etc/apt/sources.list.d/thinkpads.list`    
 
 Then update the indices and use the new repo:
 
@@ -34,7 +34,7 @@ sudo apt install dockd, libthinkpad etc...
 
 ## ~~Ubuntu~~ (obsolete, see above)
 
-The ThinkPads.org team manages a couple of official repositories for versions of Ubuntu after Xenial Xerus.     
+The libthinkpad.github.io team manages a couple of official repositories for versions of Ubuntu after Xenial Xerus.     
 That includes:
 
 * Ubuntu 17.10 Artful Ardwark (artful)
@@ -42,28 +42,28 @@ That includes:
 * Ubuntu 16.10 Yakkety Yak (yakkety)
 * Ubuntu 16.04 Xenial Xerus (xenial)
 
-To use them, first add the ThinkPads.org owner's GPG key:    
+To use them, first add the libthinkpad.github.io owner's GPG key:    
 
 
-`wget -q -O - http://thinkpads.org/repo/ubuntu/thinkpads.gpg.key | sudo apt-key add - `   
+`wget -q -O - http://libthinkpad.github.io/repo/ubuntu/thinkpads.gpg.key | sudo apt-key add - `   
    
 Next, use one of the repositories provided:
 
 * Ubuntu 17.10 Artful Ardwark (artful)    
 
-`echo "deb http://thinkpads.org/repo/ubuntu artful main" | sudo tee /etc/apt/sources.list.d/thinkpads.list`    
+`echo "deb http://libthinkpad.github.io/repo/ubuntu artful main" | sudo tee /etc/apt/sources.list.d/thinkpads.list`    
 
 * Ubuntu 17.04 Zesty Zepus (zesty)    
 
-`echo "deb http://thinkpads.org/repo/ubuntu zesty main" | sudo tee /etc/apt/sources.list.d/thinkpads.list`    
+`echo "deb http://libthinkpad.github.io/repo/ubuntu zesty main" | sudo tee /etc/apt/sources.list.d/thinkpads.list`    
 
 * Ubuntu 16.10 Yakkety Yak (yakkety)    
 
-`echo "deb http://thinkpads.org/repo/ubuntu yakkety main" | sudo tee /etc/apt/sources.list.d/thinkpads.list`    
+`echo "deb http://libthinkpad.github.io/repo/ubuntu yakkety main" | sudo tee /etc/apt/sources.list.d/thinkpads.list`    
 
 * Ubuntu 16.04 Xenial Xerus (xenial)    
 
-`echo "deb http://thinkpads.org/repo/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/thinkpads.list`    
+`echo "deb http://libthinkpad.github.io/repo/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/thinkpads.list`    
 
 ## Arch Linux
 
@@ -79,7 +79,7 @@ Special thanks to Flavio for the packaging!
 
 ## Other distros
 
-We need packagers. If you are willing to package code for ThinkPads.org for other distributions, feel free to contact    
+We need packagers. If you are willing to package code for libthinkpad.github.io for other distributions, feel free to contact    
 us at <smclt30p@gmail.com>.
 
 Currently help is wanted for:


### PR DESCRIPTION
Having in mind that Thinkpads.org is down for a while. update the related URLs in repositories.md